### PR TITLE
Move search box and change width to 10 characters

### DIFF
--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -35,11 +35,19 @@ namespace AutoDuty.Windows
             var dutyMode = Plugin.Configuration.DutyModeEnum;
             var levelingMode = Plugin.LevelingModeEnum;
 
-            DrawSearchBar();
-
             static void DrawSearchBar()
             {
-                ImGui.InputTextWithHint("##search", "Search duties...", ref _searchText, 255);
+                // Set the maximum search to 10 characters
+                uint inputMaxLength = 10;
+                
+                // Calculate the X width of the maximum amount of search characters
+                Vector2 _characterWidth = ImGui.CalcTextSize("W");
+                float inputMaxWidth = ImGui.CalcTextSize("W").X * inputMaxLength;
+                
+                // Set the width of the search box to the calculated width
+                ImGui.SetNextItemWidth(inputMaxWidth);
+                
+                ImGui.InputTextWithHint("##search", "Search duties...", ref _searchText, inputMaxLength);
 
                 // Apply filtering based on the search text
                 if (_searchText.Length > 0)
@@ -374,6 +382,9 @@ namespace AutoDuty.Windows
 
                         DrawPathSelection();
                         ImGui.Separator();
+
+                        DrawSearchBar();
+                        ImGui.SameLine();
                         if (ImGui.Checkbox("Hide Unavailable Duties", ref Plugin.Configuration.HideUnavailableDuties))
                             Plugin.Configuration.Save();
                         if (Plugin.Configuration.DutyModeEnum == DutyMode.Regular || Plugin.Configuration.DutyModeEnum == DutyMode.Trial || Plugin.Configuration.DutyModeEnum == DutyMode.Raid)


### PR DESCRIPTION
- Moved search box to area above duty list
- Clamped maximum width for search box at 10 characters via an easily-editable variable

Tested for all tabs:
![image](https://github.com/user-attachments/assets/82ba98f2-f7ab-4652-a14b-595f2e2174b6)
![image](https://github.com/user-attachments/assets/f4ba1fdc-0da6-4161-a5a0-db7509018cf1)


